### PR TITLE
fix: dead members don't break the script anymore

### DIFF
--- a/parlpy/mps/mp_fetcher.py
+++ b/parlpy/mps/mp_fetcher.py
@@ -39,6 +39,9 @@ class MPOverview:
         # jprint(response.json())
         for item in response.json()["items"]:
             value_obj = item["value"]
+            # Don't include dead people
+            if value_obj["latestHouseMembership"]["membershipEndReason"] == "Death":
+                continue
 
             values = {
                 "name_display": value_obj["nameDisplayAs"],

--- a/parlpy/test/test_mp_fetcher.py
+++ b/parlpy/test/test_mp_fetcher.py
@@ -9,5 +9,5 @@ def jprint(obj):
 
 
 mp = MPOverview()
-mp.get_all_members(verbose=True, limit=20)
+mp.get_all_members(verbose=True)
 print(mp.mp_overview_data)


### PR DESCRIPTION
Due to a dead member's party being `None`, a NoneType error occurred. Script now checks if the member is dead (and if so, moves on to next member)